### PR TITLE
Deploy faucet on nova

### DIFF
--- a/smart_contract/.env.example
+++ b/smart_contract/.env.example
@@ -1,5 +1,5 @@
 # Subspace - Nova
-RPC_URL_NOVA="https://subspace-nova.gemini-3g.subspace.network/ws"
+RPC_URL_NOVA="https://nova.gemini-3g.subspace.network/ws"
 PRIVATE_KEY_NOVA=""
 
 # Subspace - Gemini

--- a/smart_contract/.env.example
+++ b/smart_contract/.env.example
@@ -1,3 +1,7 @@
+# Subspace - Nova
+RPC_URL_NOVA="https://subspace-nova.gemini-3g.subspace.network/ws"
+PRIVATE_KEY_NOVA=""
+
 # Subspace - Gemini
 RPC_URL_GEMINI="https://domain-3.evm.gemini-3f.subspace.network/ws"
 PRIVATE_KEY_GEMINI=""
@@ -6,7 +10,8 @@ PRIVATE_KEY_GEMINI=""
 RPC_URL_GOERLI="https://goerli.infura.io/v3/"
 PRIVATE_KEY_GOERLI=""
 
-# Blockscout - Gemini
+# Blockscout - Nova&Gemini
+NOVA_SCAN_API_KEY=""
 GEMINI_SCAN_API_KEY=""
 
 # Etherscan

--- a/smart_contract/contractsAddressDeployed.json
+++ b/smart_contract/contractsAddressDeployed.json
@@ -10,5 +10,17 @@
     "blockNumber": 0,
     "tag": "Faucet deployed by deploy script",
     "extra": {}
+  },
+  {
+    "name": "Faucet",
+    "address": "0x872f3534a525023F9E42Ad69b788B44fc958D5aa",
+    "network": "nova",
+    "deployer": "0xC89F6C6DF2f2e29AfFA81E19515CC08579a93980",
+    "deploymentDate": "Wed Nov 01 2023 20:52:48 GMT-0400 (Eastern Daylight Saving Time)",
+    "chainId": 1002,
+    "blockHash": "",
+    "blockNumber": 0,
+    "tag": "Faucet deployed by deploy script",
+    "extra": {}
   }
 ]

--- a/smart_contract/contractsAddressDeployedHistory.json
+++ b/smart_contract/contractsAddressDeployedHistory.json
@@ -10,5 +10,17 @@
     "blockNumber": 0,
     "tag": "Faucet deployed by deploy script",
     "extra": {}
+  },
+  {
+    "name": "Faucet",
+    "address": "0x872f3534a525023F9E42Ad69b788B44fc958D5aa",
+    "network": "nova",
+    "deployer": "0xC89F6C6DF2f2e29AfFA81E19515CC08579a93980",
+    "deploymentDate": "Wed Nov 01 2023 20:52:48 GMT-0400 (Eastern Daylight Saving Time)",
+    "chainId": 1002,
+    "blockHash": "",
+    "blockNumber": 0,
+    "tag": "Faucet deployed by deploy script",
+    "extra": {}
   }
 ]

--- a/smart_contract/hardhat.config.ts
+++ b/smart_contract/hardhat.config.ts
@@ -1,12 +1,16 @@
-import { HardhatUserConfig } from 'hardhat/config'
-import { NetworksUserConfig } from 'hardhat/types'
 import '@nomicfoundation/hardhat-toolbox'
 import 'dotenv/config'
 import 'hardhat-awesome-cli'
+import { HardhatUserConfig } from 'hardhat/config'
+import { NetworksUserConfig } from 'hardhat/types'
 
 let networks: NetworksUserConfig = {}
 
 const {
+  // Nova
+  RPC_URL_NOVA,
+  PRIVATE_KEY_NOVA,
+  NOVA_SCAN_API_KEY,
   // Gemini 3
   RPC_URL_GEMINI,
   PRIVATE_KEY_GEMINI,
@@ -16,6 +20,14 @@ const {
   PRIVATE_KEY_GOERLI,
   ETHERSCAN_API_KEY,
 } = process.env
+
+if (RPC_URL_NOVA && PRIVATE_KEY_NOVA) {
+  networks.nova = {
+    url: RPC_URL_NOVA,
+    chainId: 1002,
+    accounts: [PRIVATE_KEY_NOVA],
+  }
+}
 
 if (RPC_URL_GEMINI && PRIVATE_KEY_GEMINI) {
   networks.gemini = {
@@ -50,10 +62,19 @@ const config: HardhatUserConfig = {
   },
   etherscan: {
     apiKey: {
+      nova: `${NOVA_SCAN_API_KEY}`,
       gemini: `${GEMINI_SCAN_API_KEY}`,
       goerli: `${ETHERSCAN_API_KEY}`,
     },
     customChains: [
+      {
+        network: 'nova',
+        chainId: 1002,
+        urls: {
+          apiURL: 'https://blockscout.subspace.network/api',
+          browserURL: 'https://blockscout.subspace.network/',
+        },
+      },
       {
         network: 'gemini',
         chainId: 1002,

--- a/smart_contract/scripts/addMinter.ts
+++ b/smart_contract/scripts/addMinter.ts
@@ -1,0 +1,23 @@
+import { addressBook, ethers, network } from 'hardhat'
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+  const deployerAddress = await deployer.getAddress()
+
+  let faucetAddressIfDeployed: string | undefined = undefined
+  faucetAddressIfDeployed = addressBook.retrieveContract('Faucet', network.name)
+  if (network.name === 'localhost' || network.name === 'hardhat')
+    faucetAddressIfDeployed = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
+
+  const faucet = await ethers.getContractAt('Faucet', faucetAddressIfDeployed, deployer)
+  const addMinter = await faucet.addMinter(deployerAddress)
+  console.log('addMinter txHash', addMinter.hash)
+
+  const receipt = await addMinter.wait()
+  console.log('receipt', receipt)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/smart_contract/scripts/createWallet.ts
+++ b/smart_contract/scripts/createWallet.ts
@@ -1,0 +1,14 @@
+import { ethers } from 'hardhat'
+
+async function main() {
+  const randomWallet = ethers.Wallet.createRandom()
+
+  console.log('randomWallet.address', randomWallet.address)
+  console.log('randomWallet.privateKey', randomWallet.privateKey)
+  console.log('randomWallet.mnemonic', randomWallet.mnemonic)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/smart_contract/scripts/faucetDetails.ts
+++ b/smart_contract/scripts/faucetDetails.ts
@@ -1,0 +1,22 @@
+import { addressBook, ethers, network } from 'hardhat'
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+
+  let faucetAddressIfDeployed: string | undefined = undefined
+  faucetAddressIfDeployed = addressBook.retrieveContract('Faucet', network.name)
+  if (network.name === 'localhost' || network.name === 'hardhat')
+    faucetAddressIfDeployed = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
+
+  const faucet = await ethers.getContractAt('Faucet', faucetAddressIfDeployed, deployer)
+  const lockTime = await faucet.lockTime()
+  console.log('lockTime', lockTime.toString())
+
+  const withdrawalAmount = await faucet.withdrawalAmount()
+  console.log('withdrawalAmount', withdrawalAmount.toString())
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/smart_contract/scripts/requestTokens.ts
+++ b/smart_contract/scripts/requestTokens.ts
@@ -1,0 +1,29 @@
+import { addressBook, ethers, network } from 'hardhat'
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+  const deployerAddress = await deployer.getAddress()
+  const deployerBalance = await deployer.provider.getBalance(deployerAddress)
+  console.log('deployerBalance', deployerBalance)
+
+  let faucetAddressIfDeployed: string | undefined = undefined
+  faucetAddressIfDeployed = addressBook.retrieveContract('Faucet', network.name)
+  if (network.name === 'localhost' || network.name === 'hardhat')
+    faucetAddressIfDeployed = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
+
+  const faucet = await ethers.getContractAt('Faucet', faucetAddressIfDeployed, deployer)
+
+  const requestTokens = await faucet.requestTokens(deployerAddress)
+  console.log('requestTokens txHash', requestTokens.hash)
+
+  const receipt = await requestTokens.wait()
+  console.log('receipt', receipt)
+
+  const deployerBalanceFinal = await deployer.provider.getBalance(deployerAddress)
+  console.log('deployerBalance', deployerBalanceFinal)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/smart_contract/scripts/setup.ts
+++ b/smart_contract/scripts/setup.ts
@@ -1,0 +1,45 @@
+import { addressBook, ethers, network } from 'hardhat'
+
+const SECONDS_BETWEEN_REQUEST = 60 * 60 * 24
+const AMOUNT_BY_REQUEST = ethers.parseEther('0.2')
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+  const deployerAddress = await deployer.getAddress()
+
+  let faucetAddressIfDeployed: string | undefined = undefined
+  faucetAddressIfDeployed = addressBook.retrieveContract('Faucet', network.name)
+  if (network.name === 'localhost' || network.name === 'hardhat')
+    faucetAddressIfDeployed = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
+
+  const faucet = await ethers.getContractAt('Faucet', faucetAddressIfDeployed, deployer)
+
+  const lockTime = await faucet.lockTime()
+  console.log('lockTime', lockTime.toString())
+
+  const setLockTime = await faucet.setLockTime(SECONDS_BETWEEN_REQUEST)
+  console.log('setLockTime txHash', setLockTime.hash)
+
+  const receipt = await setLockTime.wait()
+  console.log('receipt', receipt)
+
+  const lockTimeFinal = await faucet.lockTime()
+  console.log('lockTimeFinal', lockTimeFinal.toString())
+
+  const withdrawalAmount = await faucet.withdrawalAmount()
+  console.log('withdrawalAmount', withdrawalAmount.toString())
+
+  const setWithdrawalAmount = await faucet.setWithdrawalAmount(AMOUNT_BY_REQUEST)
+  console.log('setWithdrawalAmount txHash', setWithdrawalAmount.hash)
+
+  const receipt2 = await setWithdrawalAmount.wait()
+  console.log('receipt', receipt2)
+
+  const withdrawalAmountFinal = await faucet.withdrawalAmount()
+  console.log('withdrawalAmountFinal', withdrawalAmountFinal.toString())
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/web-app/src/constants/contracts.ts
+++ b/web-app/src/constants/contracts.ts
@@ -72,7 +72,7 @@ export const contracts: Contract[] = [
   {
     chainId: 1002,
     name: 'Faucet',
-    address: `0x74377fe8209015Bf6e58e52CC0fe2F1bDA8102B3`,
+    address: `0x872f3534a525023F9E42Ad69b788B44fc958D5aa`,
     abi: FAUCET
   }
 ]


### PR DESCRIPTION
## deploy faucet on nova

- Faucet deployed at 0x872f3534a525023F9E42Ad69b788B44fc958D5aa on Nova
- Add Hardhat config for nova network
- Add a few scripts to make it easier to setup, test, and verify everything is working with the faucet
- Change the address of the faucet contract in the constants of the web app

### Contract verification

Ounce the Blockscout explorer ENV are change to point to the new RPC, we will be able to verify the contract