### PR TITLE
Deploy faucet on nova domain id1

### DIFF
--- a/smart_contract/contractsAddressDeployed.json
+++ b/smart_contract/contractsAddressDeployed.json
@@ -13,10 +13,10 @@
   },
   {
     "name": "Faucet",
-    "address": "0x872f3534a525023F9E42Ad69b788B44fc958D5aa",
+    "address": "0x238060160E04D938a34bDf425396384dC878F5E8",
     "network": "nova",
     "deployer": "0xC89F6C6DF2f2e29AfFA81E19515CC08579a93980",
-    "deploymentDate": "Wed Nov 01 2023 20:52:48 GMT-0400 (Eastern Daylight Saving Time)",
+    "deploymentDate": "Mon Nov 06 2023 20:14:02 GMT-0500 (Eastern Standard Time)",
     "chainId": 1002,
     "blockHash": "",
     "blockNumber": 0,

--- a/smart_contract/contractsAddressDeployedHistory.json
+++ b/smart_contract/contractsAddressDeployedHistory.json
@@ -22,5 +22,17 @@
     "blockNumber": 0,
     "tag": "Faucet deployed by deploy script",
     "extra": {}
+  },
+  {
+    "name": "Faucet",
+    "address": "0x238060160E04D938a34bDf425396384dC878F5E8",
+    "network": "nova",
+    "deployer": "0xC89F6C6DF2f2e29AfFA81E19515CC08579a93980",
+    "deploymentDate": "Mon Nov 06 2023 20:14:02 GMT-0500 (Eastern Standard Time)",
+    "chainId": 1002,
+    "blockHash": "",
+    "blockNumber": 0,
+    "tag": "Faucet deployed by deploy script",
+    "extra": {}
   }
 ]

--- a/smart_contract/hardhat.config.ts
+++ b/smart_contract/hardhat.config.ts
@@ -71,8 +71,8 @@ const config: HardhatUserConfig = {
         network: 'nova',
         chainId: 1002,
         urls: {
-          apiURL: 'https://blockscout.subspace.network/api',
-          browserURL: 'https://blockscout.subspace.network/',
+          apiURL: 'https://nova.subspace.network/api',
+          browserURL: 'https://nova.subspace.network/',
         },
       },
       {

--- a/web-app/src/constants/contracts.ts
+++ b/web-app/src/constants/contracts.ts
@@ -72,7 +72,7 @@ export const contracts: Contract[] = [
   {
     chainId: 1002,
     name: 'Faucet',
-    address: `0x872f3534a525023F9E42Ad69b788B44fc958D5aa`,
+    address: `0x238060160E04D938a34bDf425396384dC878F5E8`,
     abi: FAUCET
   }
 ]


### PR DESCRIPTION
## Deploy faucet on nova domain id1

- Deploy Faucet contract on Nova domain id 1
- Change contracts address on Faucet web-app
- Add Nova api endpoint and explorer in hardhat config